### PR TITLE
Fix middleware configuration isolation and nil profile handling

### DIFF
--- a/lib/verikloak/audience/checker.rb
+++ b/lib/verikloak/audience/checker.rb
@@ -15,7 +15,8 @@ module Verikloak
       # @param cfg [Verikloak::Audience::Configuration]
       # @return [Boolean]
       def ok?(claims, cfg)
-        profile = cfg.profile.to_sym
+        profile = cfg.profile
+        profile = profile.to_sym if profile.respond_to?(:to_sym)
         profile = :strict_single unless %i[strict_single allow_account resource_or_aud].include?(profile)
 
         case profile

--- a/lib/verikloak/audience/checker.rb
+++ b/lib/verikloak/audience/checker.rb
@@ -7,6 +7,8 @@ module Verikloak
     # This module provides predicate helpers used by the middleware to decide
     # whether a given set of claims satisfies the configured profile.
     module Checker
+      VALID_PROFILES = %i[strict_single allow_account resource_or_aud].freeze
+
       module_function
 
       # Returns whether the given claims satisfy the configured profile.
@@ -19,7 +21,12 @@ module Verikloak
 
         profile = cfg.profile
         profile = profile.to_sym if profile.respond_to?(:to_sym)
-        profile = :strict_single unless %i[strict_single allow_account resource_or_aud].include?(profile)
+        profile = :strict_single if profile.nil?
+
+        unless VALID_PROFILES.include?(profile)
+          raise Verikloak::Audience::ConfigurationError,
+                "unknown audience profile #{cfg.profile.inspect}"
+        end
 
         case profile
         when :strict_single

--- a/lib/verikloak/audience/checker.rb
+++ b/lib/verikloak/audience/checker.rb
@@ -15,6 +15,8 @@ module Verikloak
       # @param cfg [Verikloak::Audience::Configuration]
       # @return [Boolean]
       def ok?(claims, cfg)
+        claims = normalize_claims(claims)
+
         profile = cfg.profile
         profile = profile.to_sym if profile.respond_to?(:to_sym)
         profile = :strict_single unless %i[strict_single allow_account resource_or_aud].include?(profile)
@@ -78,6 +80,8 @@ module Verikloak
       # @param cfg [Verikloak::Audience::Configuration]
       # @return [:strict_single, :allow_account, :resource_or_aud]
       def suggest(claims, cfg)
+        claims = normalize_claims(claims)
+
         aud = Array(claims['aud']).map(&:to_s)
         req = cfg.required_aud_list
         has_roles = !Array(claims.dig('resource_access', cfg.resource_client.to_s, 'roles')).empty?
@@ -88,6 +92,27 @@ module Verikloak
 
         :strict_single
       end
+
+      # Normalize incoming claims to a Hash to guard against unexpected
+      # env payloads or middleware ordering issues.
+      #
+      # @param claims [Object]
+      # @return [Hash]
+      def normalize_claims(claims)
+        return {} if claims.nil?
+        return claims if claims.is_a?(Hash)
+
+        if claims.respond_to?(:to_hash)
+          coerced = claims.to_hash
+          return coerced if coerced.is_a?(Hash)
+        end
+
+        {}
+      rescue StandardError
+        {}
+      end
+      module_function :normalize_claims
+      private_class_method :normalize_claims
     end
   end
 end

--- a/lib/verikloak/audience/configuration.rb
+++ b/lib/verikloak/audience/configuration.rb
@@ -21,7 +21,8 @@ module Verikloak
     #   @return [Boolean]
     class Configuration
       attr_accessor :profile, :required_aud, :resource_client,
-                    :env_claims_key, :suggest_in_logs
+                    :suggest_in_logs
+      attr_reader :env_claims_key
 
       # Create a configuration with safe defaults.
       #
@@ -30,7 +31,7 @@ module Verikloak
         @profile         = :strict_single
         @required_aud    = []
         @resource_client = 'rails-api'
-        @env_claims_key  = 'verikloak.user'
+        self.env_claims_key  = 'verikloak.user'
         @suggest_in_logs = true
       end
 
@@ -43,7 +44,7 @@ module Verikloak
         @profile         = safe_dup(source.profile)
         @required_aud    = duplicate_required_aud(source.required_aud)
         @resource_client = safe_dup(source.resource_client)
-        @env_claims_key  = safe_dup(source.env_claims_key)
+        self.env_claims_key = safe_dup(source.env_claims_key)
         @suggest_in_logs = source.suggest_in_logs
       end
 
@@ -52,6 +53,12 @@ module Verikloak
       # @return [Array<String>]
       def required_aud_list
         Array(required_aud).map(&:to_s)
+      end
+
+      # @param value [#to_s, nil]
+      # @return [void]
+      def env_claims_key=(value)
+        @env_claims_key = value&.to_s
       end
 
       private

--- a/lib/verikloak/audience/configuration.rb
+++ b/lib/verikloak/audience/configuration.rb
@@ -40,8 +40,8 @@ module Verikloak
       # @return [void]
       def initialize_copy(source)
         super
-        @profile         = source.profile
-        @required_aud    = source.required_aud.is_a?(Array) ? source.required_aud.dup : source.required_aud
+        @profile         = safe_dup(source.profile)
+        @required_aud    = duplicate_required_aud(source.required_aud)
         @resource_client = safe_dup(source.resource_client)
         @env_claims_key  = safe_dup(source.env_claims_key)
         @suggest_in_logs = source.suggest_in_logs
@@ -62,6 +62,14 @@ module Verikloak
         value.dup
       rescue TypeError
         value
+      end
+
+      def duplicate_required_aud(value)
+        return if value.nil?
+
+        return value.map { |item| safe_dup(item) } if value.is_a?(Array)
+
+        safe_dup(value)
       end
     end
   end

--- a/lib/verikloak/audience/configuration.rb
+++ b/lib/verikloak/audience/configuration.rb
@@ -34,11 +34,34 @@ module Verikloak
         @suggest_in_logs = true
       end
 
+      # Ensure `dup` produces an independent copy.
+      #
+      # @param source [Configuration]
+      # @return [void]
+      def initialize_copy(source)
+        super
+        @profile         = source.profile
+        @required_aud    = source.required_aud.is_a?(Array) ? source.required_aud.dup : source.required_aud
+        @resource_client = safe_dup(source.resource_client)
+        @env_claims_key  = safe_dup(source.env_claims_key)
+        @suggest_in_logs = source.suggest_in_logs
+      end
+
       # Coerce `required_aud` into an array of strings.
       #
       # @return [Array<String>]
       def required_aud_list
         Array(required_aud).map(&:to_s)
+      end
+
+      private
+
+      def safe_dup(value)
+        return if value.nil?
+
+        value.dup
+      rescue TypeError
+        value
       end
     end
   end

--- a/lib/verikloak/audience/configuration.rb
+++ b/lib/verikloak/audience/configuration.rb
@@ -31,7 +31,7 @@ module Verikloak
         @profile         = :strict_single
         @required_aud    = []
         @resource_client = 'rails-api'
-        self.env_claims_key  = 'verikloak.user'
+        self.env_claims_key = 'verikloak.user'
         @suggest_in_logs = true
       end
 
@@ -63,6 +63,11 @@ module Verikloak
 
       private
 
+      # Attempt to duplicate a value while tolerating non-duplicable inputs.
+      # Returns `nil` when given nil and falls back to the original on duplication errors.
+      #
+      # @param value [Object, nil]
+      # @return [Object, nil]
       def safe_dup(value)
         return if value.nil?
 

--- a/lib/verikloak/audience/errors.rb
+++ b/lib/verikloak/audience/errors.rb
@@ -23,17 +23,27 @@ module Verikloak
       end
     end
 
-    # Raised when audience is insufficient for the configured profile.
+    # Raised when verified claims do not satisfy the configured profile.
+    # Typically emitted when the required audience list is empty or
+    # mismatches the token audiences.
     class Forbidden < Error
-      # @param msg [String]
+      # Build a forbidden error with a customizable message while preserving
+      # the standard machine-friendly code and HTTP status.
+      #
+      # @param msg [String] alternate human-readable explanation
       def initialize(msg = 'insufficient audience')
         super(msg, code: 'insufficient_audience', http_status: 403)
       end
     end
 
     # Raised when configuration is invalid.
+    # Used when runtime configuration checks detect missing or incompatible
+    # values before audience validation takes place.
     class ConfigurationError < Error
-      # @param msg [String]
+      # Build a configuration error while keeping a consistent error code
+      # and a 500 HTTP status to signal an internal misconfiguration.
+      #
+      # @param msg [String] alternate human-readable explanation
       def initialize(msg = 'invalid audience configuration')
         super(msg, code: 'audience_configuration_error', http_status: 500)
       end

--- a/lib/verikloak/audience/errors.rb
+++ b/lib/verikloak/audience/errors.rb
@@ -30,5 +30,13 @@ module Verikloak
         super(msg, code: 'insufficient_audience', http_status: 403)
       end
     end
+
+    # Raised when configuration is invalid.
+    class ConfigurationError < Error
+      # @param msg [String]
+      def initialize(msg = 'invalid audience configuration')
+        super(msg, code: 'audience_configuration_error', http_status: 500)
+      end
+    end
   end
 end

--- a/lib/verikloak/audience/middleware.rb
+++ b/lib/verikloak/audience/middleware.rb
@@ -22,7 +22,7 @@ module Verikloak
       # @option opts [Boolean] :suggest_in_logs
       def initialize(app, **opts)
         @app = app
-        @config = Verikloak::Audience.configure
+        @config = Verikloak::Audience.config.dup
         apply_overrides!(opts)
       end
 

--- a/lib/verikloak/audience/middleware.rb
+++ b/lib/verikloak/audience/middleware.rb
@@ -31,7 +31,8 @@ module Verikloak
       # @param env [Hash] Rack environment
       # @return [Array(Integer, Hash, #each)] Rack response triple
       def call(env)
-        claims = env[@config.env_claims_key] || {}
+        env_key = @config.env_claims_key
+        claims = env[env_key] || env[env_key&.to_sym] || {}
         return @app.call(env) if Checker.ok?(claims, @config)
 
         if @config.suggest_in_logs
@@ -54,8 +55,16 @@ module Verikloak
       # @return [void]
       def apply_overrides!(opts)
         cfg = @config
+        opts.each_key do |key|
+          writer = "#{key}="
+          next if cfg.respond_to?(writer)
+
+          raise Verikloak::Audience::ConfigurationError,
+                "unknown middleware option :#{key}"
+        end
+
         opts.each do |k, v|
-          cfg.public_send("#{k}=", v) if cfg.respond_to?("#{k}=")
+          cfg.public_send("#{k}=", v)
         end
       end
     end

--- a/spec/audience_checker_spec.rb
+++ b/spec/audience_checker_spec.rb
@@ -57,16 +57,17 @@ RSpec.describe Verikloak::Audience::Checker do
     expect(described_class.ok?(claims, cfg)).to be true
   end
 
-  it "falls back to strict_single when profile unknown" do
-    cfg.profile = :unknown_profile
-    claims = { "aud" => ["rails-api"] }
-    expect(described_class.ok?(claims, cfg)).to be true
-  end
-
   it "defaults to strict_single when profile is nil" do
     cfg.profile = nil
     claims = { "aud" => ["rails-api"] }
     expect(described_class.ok?(claims, cfg)).to be true
+  end
+
+  it "raises when profile is not recognized" do
+    cfg.profile = :unknown_profile
+    expect {
+      described_class.ok?({ "aud" => ["rails-api"] }, cfg)
+    }.to raise_error(Verikloak::Audience::ConfigurationError, /unknown audience profile/)
   end
 
   it "treats non-hash claims as empty when evaluating" do

--- a/spec/audience_checker_spec.rb
+++ b/spec/audience_checker_spec.rb
@@ -62,4 +62,10 @@ RSpec.describe Verikloak::Audience::Checker do
     claims = { "aud" => ["rails-api"] }
     expect(described_class.ok?(claims, cfg)).to be true
   end
+
+  it "defaults to strict_single when profile is nil" do
+    cfg.profile = nil
+    claims = { "aud" => ["rails-api"] }
+    expect(described_class.ok?(claims, cfg)).to be true
+  end
 end

--- a/spec/audience_checker_spec.rb
+++ b/spec/audience_checker_spec.rb
@@ -68,4 +68,13 @@ RSpec.describe Verikloak::Audience::Checker do
     claims = { "aud" => ["rails-api"] }
     expect(described_class.ok?(claims, cfg)).to be true
   end
+
+  it "treats non-hash claims as empty when evaluating" do
+    cfg.profile = :resource_or_aud
+    expect(described_class.ok?("not a hash", cfg)).to be false
+  end
+
+  it "treats non-hash claims as empty when suggesting" do
+    expect(described_class.suggest("invalid", cfg)).to eq(:strict_single)
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -37,5 +37,12 @@ RSpec.describe Verikloak::Audience::Configuration do
     expect(cfg.resource_client).to eq "api"
     expect(cfg.env_claims_key).to eq "claims"
   end
+
+  it "normalizes env_claims_key to strings" do
+    cfg = described_class.new
+    cfg.env_claims_key = :claims
+
+    expect(cfg.env_claims_key).to eq("claims")
+  end
 end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -18,5 +18,24 @@ RSpec.describe Verikloak::Audience::Configuration do
     expect(cfg.env_claims_key).to eq "verikloak.user"
     expect(cfg.suggest_in_logs).to be true
   end
+
+  it "duplicates mutable attributes when copied" do
+    cfg = described_class.new
+    cfg.profile = "strict_single"
+    cfg.required_aud = ["base"]
+    cfg.resource_client = "api"
+    cfg.env_claims_key = "claims"
+
+    duped = cfg.dup
+    duped.profile.replace("allow_account")
+    duped.required_aud << "extra"
+    duped.resource_client.replace("other")
+    duped.env_claims_key.replace("other.claims")
+
+    expect(cfg.profile).to eq "strict_single"
+    expect(cfg.required_aud).to eq ["base"]
+    expect(cfg.resource_client).to eq "api"
+    expect(cfg.env_claims_key).to eq "claims"
+  end
 end
 

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -75,4 +75,17 @@ RSpec.describe Verikloak::Audience::Middleware do
     expect(res.status).to eq 403
     expect(res.body).to include "insufficient_audience"
   end
+
+  it "reads symbol env keys safely" do
+    middleware = described_class.new(inner_app, profile: :strict_single, required_aud: ["rails-api"], env_claims_key: :claims)
+    response = middleware.call({ claims: { "aud" => ["rails-api"] } })
+
+    expect(response[0]).to eq(200)
+  end
+
+  it "raises when unknown options are provided" do
+    expect {
+      described_class.new(inner_app, profile: :strict_single, foo: :bar)
+    }.to raise_error(Verikloak::Audience::ConfigurationError, /unknown middleware option/)
+  end
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -68,4 +68,11 @@ RSpec.describe Verikloak::Audience::Middleware do
       cfg.required_aud = []
     end
   end
+
+  it "treats non-hash claims as missing" do
+    app = build_app(profile: :strict_single, required_aud: ["rails-api"], env_claims_key: "claims")
+    res = Rack::MockRequest.new(app).get("/", { "claims" => "garbage" })
+    expect(res.status).to eq 403
+    expect(res.body).to include "insufficient_audience"
+  end
 end


### PR DESCRIPTION
## Summary
- duplicate the shared configuration when instantiating the Rack middleware so per-mount overrides stay isolated
- ensure Configuration#dup copies mutable fields safely and exercise the behaviour in middleware specs
- tolerate nil profiles in the Checker and cover the regression with specs