### PR TITLE
Validate audience configuration and align logging with Rack loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped runtime dependency to `verikloak >= 0.1.5` to pick up shared logger support.
 - Improved Rails Railtie test harness to mimic real initializer registration.
 
+## [0.1.1] - 2025-09-20
+
+### Changed
+- Documented `Configuration#safe_dup` behaviour and tightened duplication semantics.
+- Expanded error class YARD docs to clarify operational response codes.
+
 ## [0.1.0] - 2025-09-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.1.1] - 2025-09-20
+## [0.2.0] - 2025-09-21
+
+### Added
+- README "Operational safeguards" section covering startup validation, logger precedence, and `:resource_or_aud` alignment guidance.
+- YARD documentation for configuration helpers and middleware logging routines.
 
 ### Changed
-- Documented `Configuration#safe_dup` behaviour and error handling in YARD.
-- Expanded error class documentation for clearer release guidance.
+- Tightened `resource_client` inference/validation to enforce alignment with `required_aud` and infer single-entry clients automatically.
+- Prefer request-scoped loggers over `Kernel#warn` when emitting audience failure messages.
+- Bumped runtime dependency to `verikloak >= 0.1.5` to pick up shared logger support.
+- Improved Rails Railtie test harness to mimic real initializer registration.
 
 ## [0.1.0] - 2025-09-20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-audience (0.1.1)
+    verikloak-audience (0.2.0)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.1.5, < 1.0.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     verikloak-audience (0.1.1)
       rack (>= 2.2, < 4.0)
-      verikloak (>= 0.1.2, < 0.2)
+      verikloak (>= 0.1.5, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -21,6 +21,8 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
     json (2.13.2)
     jwt (3.1.2)
       base64
@@ -88,13 +90,15 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
     uri (1.0.3)
-    verikloak (0.1.3)
+    verikloak (0.1.5)
       faraday (>= 2.0, < 3.0)
+      faraday-retry (>= 2.0, < 3.0)
       json (~> 2.6)
       jwt (>= 2.7, < 4.0)
 
 PLATFORMS
   aarch64-linux-musl
+  arm64-darwin-24
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ See [`examples/rack.ru`](examples/rack.ru) for a full Rack sample. In Rails, alw
 
 `env_claims_key` assumes the preceding `Verikloak::Middleware` populates the Rack env. If the middleware order changes, claims will be missing and the audience check will always reject.
 
+### Operational safeguards
+- Middleware initialisation now fails fast when `required_aud` is empty. When Rails loads via the supplied Railtie, `Verikloak::Audience.config.validate!` runs after boot so configuration mistakes surface during startup instead of returning 403 for every request.
+- When audience validation fails, the middleware consults `env['verikloak.logger']`, `env['rack.logger']`, and `env['action_dispatch.logger']` (in that order) before falling back to Ruby's `Kernel#warn`, keeping failure logs consistent with Rails and Verikloak observers.
+- For the `:resource_or_aud` profile, `resource_client` must match one of the values in `required_aud`. A single-element `required_aud` automatically infers the client id, ensuring the same client identifier is shared with downstream BFF/Pundit integrations.
+
 ## Testing
 All pull requests and pushes are automatically tested with [RSpec](https://rspec.info/) and [RuboCop](https://rubocop.org/) via GitHub Actions.
 See the CI badge at the top for current build status.

--- a/lib/verikloak/audience/middleware.rb
+++ b/lib/verikloak/audience/middleware.rb
@@ -39,7 +39,8 @@ module Verikloak
         if @config.suggest_in_logs
           suggestion = Checker.suggest(claims, @config)
           aud_view = Array(claims['aud']).inspect
-          log_warning(env, "[verikloak-audience] insufficient_audience; suggestion profile=:#{suggestion} aud=#{aud_view}")
+          log_warning(env,
+                      "[verikloak-audience] insufficient_audience; suggestion profile=:#{suggestion} aud=#{aud_view}")
         end
 
         body = { error: 'insufficient_audience',
@@ -52,7 +53,7 @@ module Verikloak
 
       # Apply provided options to the configuration instance.
       #
-      # @param opts [Hash]
+      # @param opts [Hash] raw overrides provided to the middleware
       # @return [void]
       def apply_overrides!(opts)
         cfg = @config
@@ -69,9 +70,15 @@ module Verikloak
         end
       end
 
+      # Emit a warning for failed audience checks using request-scoped loggers
+      # when available.
+      #
+      # @param env [Hash] Rack environment
+      # @param message [String] warning payload
+      # @return [void]
       def log_warning(env, message)
         logger = env['verikloak.logger'] || env['rack.logger'] || env['action_dispatch.logger']
-        if logger&.respond_to?(:warn)
+        if logger.respond_to?(:warn)
           logger.warn(message)
         else
           warn(message)

--- a/lib/verikloak/audience/railtie.rb
+++ b/lib/verikloak/audience/railtie.rb
@@ -33,6 +33,12 @@ module Verikloak
         self.class.insert_middleware(app)
       end
 
+      initializer 'verikloak_audience.configuration' do
+        config.after_initialize do
+          Verikloak::Audience.config.validate!
+        end
+      end
+
       # Performs the insertion into the middleware stack when the core
       # Verikloak middleware is available. Extracted for testability without
       # requiring a full Rails boot process.

--- a/lib/verikloak/audience/version.rb
+++ b/lib/verikloak/audience/version.rb
@@ -4,6 +4,6 @@ module Verikloak
   module Audience
     # Current gem version.
     # @return [String]
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -44,5 +44,33 @@ RSpec.describe Verikloak::Audience::Configuration do
 
     expect(cfg.env_claims_key).to eq("claims")
   end
+
+  describe "#validate!" do
+    it "raises when required_aud is empty" do
+      cfg = described_class.new
+      cfg.required_aud = []
+
+      expect { cfg.validate! }.to raise_error(Verikloak::Audience::ConfigurationError)
+    end
+
+    it "infers resource_client from required_aud when profile resource_or_aud" do
+      cfg = described_class.new
+      cfg.profile = :resource_or_aud
+      cfg.required_aud = ['bff-api']
+      cfg.resource_client = described_class::DEFAULT_RESOURCE_CLIENT
+
+      expect(cfg.validate!.resource_client).to eq('bff-api')
+    end
+
+    it "raises when resource_client is not in required_aud" do
+      cfg = described_class.new
+      cfg.profile = :resource_or_aud
+      cfg.required_aud = %w[first second]
+      cfg.resource_client = 'other'
+
+      expect { cfg.validate! }.to raise_error(Verikloak::Audience::ConfigurationError,
+                                              /resource_client must match one of required_aud/)
+    end
+  end
 end
 

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -7,12 +7,32 @@ require 'spec_helper'
 unless defined?(Rails::Railtie)
   module Rails
     class Railtie
+      class Config
+        attr_reader :after_initialize_callbacks
+
+        def initialize
+          @after_initialize_callbacks = []
+        end
+
+        def after_initialize(&block)
+          @after_initialize_callbacks << block if block
+        end
+      end
+
       def self.initializers
         @initializers ||= []
       end
 
       def self.initializer(name, &block)
         initializers << [name, block]
+      end
+
+      def self.config
+        @config ||= Config.new
+      end
+
+      def config
+        self.class.config
       end
     end
   end
@@ -46,5 +66,26 @@ RSpec.describe Verikloak::Audience::Railtie do
     end
     expect(middleware_stack).not_to receive(:insert_after)
     described_class.insert_middleware(app)
+  end
+
+  it 'validates configuration after Rails initialization' do
+    initializer = Rails::Railtie.initializers.find { |name, _| name == 'verikloak_audience.configuration' }
+    expect(initializer).not_to be_nil
+
+    described_class.config.after_initialize_callbacks.clear
+
+    railtie = described_class.new
+    expect {
+      railtie.instance_eval(&initializer[1])
+    }.to change { described_class.config.after_initialize_callbacks.size }.by(1)
+
+    callback = described_class.config.after_initialize_callbacks.last
+    config_double = instance_double(Verikloak::Audience::Configuration)
+    allow(Verikloak::Audience).to receive(:config).and_return(config_double)
+    expect(config_double).to receive(:validate!).and_return(config_double)
+
+    callback.call
+  ensure
+    described_class.config.after_initialize_callbacks.clear
   end
 end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -24,7 +24,9 @@ unless defined?(Rails::Railtie)
       end
 
       def self.initializer(name, &block)
-        initializers << [name, block]
+        entry = [name, block]
+        initializers << entry
+        Rails::Railtie.initializers << entry unless equal?(Rails::Railtie)
       end
 
       def self.config

--- a/verikloak-audience.gemspec
+++ b/verikloak-audience.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.add_dependency 'verikloak', '>= 0.1.2', '< 0.2'
+  spec.add_dependency 'verikloak', '>= 0.1.5', '< 1.0.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
## Summary
- add Configuration#validate! to enforce required audiences and infer resource_client for resource_or_aud profiles
- teach the Rack middleware to validate configuration on boot and emit suggestions through Rack-provided loggers when available
- hook the Railtie into Rails' after_initialize to validate configuration, and extend specs to cover the new behaviour