### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.1] - 2025-09-22
+
+### Fixed
+- Skip configuration validation while Rails generators run so `rails g verikloak:install` can execute before `required_aud` is configured.
+
 ## [0.2.0] - 2025-09-21
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    verikloak-audience (0.2.0)
+    verikloak-audience (0.2.1)
       rack (>= 2.2, < 4.0)
-      verikloak (>= 0.1.5, < 1.0.0)
+      verikloak (>= 0.2.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -90,7 +90,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
     uri (1.0.3)
-    verikloak (0.1.5)
+    verikloak (0.2.0)
       faraday (>= 2.0, < 3.0)
       faraday-retry (>= 2.0, < 3.0)
       json (~> 2.6)

--- a/lib/verikloak/audience/version.rb
+++ b/lib/verikloak/audience/version.rb
@@ -4,6 +4,6 @@ module Verikloak
   module Audience
     # Current gem version.
     # @return [String]
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -46,6 +46,9 @@ require 'verikloak/audience/railtie'
 RSpec.describe Verikloak::Audience::Railtie do
   let(:middleware_stack) { instance_double('MiddlewareStack') }
   let(:app) { instance_double('RailsApp', middleware: middleware_stack) }
+  let(:configuration_initializer) do
+    Rails::Railtie.initializers.find { |name, _| name == 'verikloak_audience.configuration' }
+  end
 
   it 'inserts after Verikloak::Middleware when defined' do
     begin
@@ -71,14 +74,13 @@ RSpec.describe Verikloak::Audience::Railtie do
   end
 
   it 'validates configuration after Rails initialization' do
-    initializer = Rails::Railtie.initializers.find { |name, _| name == 'verikloak_audience.configuration' }
-    expect(initializer).not_to be_nil
+    expect(configuration_initializer).not_to be_nil
 
     described_class.config.after_initialize_callbacks.clear
 
     railtie = described_class.new
     expect {
-      railtie.instance_eval(&initializer[1])
+      railtie.instance_eval(&configuration_initializer[1])
     }.to change { described_class.config.after_initialize_callbacks.size }.by(1)
 
     callback = described_class.config.after_initialize_callbacks.last
@@ -89,5 +91,29 @@ RSpec.describe Verikloak::Audience::Railtie do
     callback.call
   ensure
     described_class.config.after_initialize_callbacks.clear
+  end
+
+  it 'skips validation during generator commands' do
+    expect(configuration_initializer).not_to be_nil
+
+    described_class.config.after_initialize_callbacks.clear
+
+    original_argv = ARGV.dup
+
+    stub_const('Rails::Generators', Module.new)
+    ARGV.replace(['generate', 'verikloak:install'])
+
+    railtie = described_class.new
+    railtie.instance_eval(&configuration_initializer[1])
+
+    callback = described_class.config.after_initialize_callbacks.last
+    config_double = instance_double(Verikloak::Audience::Configuration)
+    allow(Verikloak::Audience).to receive(:config).and_return(config_double)
+    expect(config_double).not_to receive(:validate!)
+
+    callback.call
+  ensure
+    described_class.config.after_initialize_callbacks.clear
+    ARGV.replace(original_argv)
   end
 end

--- a/verikloak-audience.gemspec
+++ b/verikloak-audience.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.add_dependency 'verikloak', '>= 0.1.5', '< 1.0.0'
+  spec.add_dependency 'verikloak', '>= 0.2.0', '< 1.0.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
- Skip configuration validation while Rails generators run so rails g verikloak:install can complete before required_aud is configured.
- Document the fix in the changelog and bump the gem version to 0.2.1.