### PR TITLE
Prepare v0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.2] - 2025-09-22
+
+### Fixed
+- Skip middleware configuration validation when Rails generator commands execute so `rails g verikloak:install` can boot without preconfigured audiences.
+
 ## [0.2.1] - 2025-09-22
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-audience (0.2.1)
+    verikloak-audience (0.2.2)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.2.0, < 1.0.0)
 

--- a/lib/verikloak/audience/middleware.rb
+++ b/lib/verikloak/audience/middleware.rb
@@ -77,6 +77,7 @@ module Verikloak
       # @return [Boolean]
       def skip_validation?
         return false unless defined?(::Verikloak::Audience::Railtie)
+        return false unless ::Verikloak::Audience::Railtie.respond_to?(:skip_configuration_validation?)
 
         ::Verikloak::Audience::Railtie.skip_configuration_validation?
       end

--- a/lib/verikloak/audience/middleware.rb
+++ b/lib/verikloak/audience/middleware.rb
@@ -24,7 +24,7 @@ module Verikloak
         @app = app
         @config = Verikloak::Audience.config.dup
         apply_overrides!(opts)
-        @config.validate!
+        @config.validate! unless skip_validation?
       end
 
       # Evaluate the request against the audience profile.
@@ -68,6 +68,17 @@ module Verikloak
         opts.each do |k, v|
           cfg.public_send("#{k}=", v)
         end
+      end
+
+      # Determine whether configuration validation should run. This allows
+      # Rails generators to boot without a fully-populated configuration since
+      # the install task is responsible for creating it.
+      #
+      # @return [Boolean]
+      def skip_validation?
+        return false unless defined?(::Verikloak::Audience::Railtie)
+
+        ::Verikloak::Audience::Railtie.skip_configuration_validation?
       end
 
       # Emit a warning for failed audience checks using request-scoped loggers

--- a/lib/verikloak/audience/version.rb
+++ b/lib/verikloak/audience/version.rb
@@ -4,6 +4,6 @@ module Verikloak
   module Audience
     # Current gem version.
     # @return [String]
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
   end
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -111,4 +111,18 @@ RSpec.describe Verikloak::Audience::Middleware do
       described_class.new(inner_app)
     }.to raise_error(Verikloak::Audience::ConfigurationError, /required_aud/)
   end
+
+  it "skips validation when Railtie indicates generator command" do
+    railtie = Class.new do
+      def self.skip_configuration_validation?
+        true
+      end
+    end
+
+    stub_const("Verikloak::Audience::Railtie", railtie)
+
+    expect {
+      described_class.new(inner_app)
+    }.not_to raise_error
+  end
 end


### PR DESCRIPTION
## Summary
- bypass middleware validation when Rails generators boot
- bump version to 0.2.2 and document the fix in the changelog
