### PR TITLE
Prepare v0.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.3] - 2025-09-22
+
+### Fixed
+- Detect the `verikloak:install` namespace after Rails strips the `g` alias so generator invocations inside wrappers (e.g. `docker compose run`) no longer fail validation.
+
 ## [0.2.2] - 2025-09-22
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-audience (0.2.2)
+    verikloak-audience (0.2.3)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.2.0, < 1.0.0)
 

--- a/lib/verikloak/audience/railtie.rb
+++ b/lib/verikloak/audience/railtie.rb
@@ -53,7 +53,11 @@ module Verikloak
         app.middleware.insert_after ::Verikloak::Middleware, ::Verikloak::Audience::Middleware
       end
 
-      COMMANDS_SKIPPING_VALIDATION = %w[generate g destroy d].freeze
+      # Rails short commands (`g`, `d`) are stripped from ARGV fairly early in
+      # the boot process. When that happens the first argument becomes the
+      # generator namespace (e.g. `verikloak:install`). Include it here so the
+      # install generator can run before `required_aud` is configured.
+      COMMANDS_SKIPPING_VALIDATION = %w[generate g destroy d verikloak:install].freeze
 
       # Detect whether Rails is currently executing a generator-style command.
       # Generators boot the application before configuration exists, so we

--- a/lib/verikloak/audience/version.rb
+++ b/lib/verikloak/audience/version.rb
@@ -4,6 +4,6 @@ module Verikloak
   module Audience
     # Current gem version.
     # @return [String]
-    VERSION = '0.2.2'
+    VERSION = '0.2.3'
   end
 end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -116,4 +116,28 @@ RSpec.describe Verikloak::Audience::Railtie do
     described_class.config.after_initialize_callbacks.clear
     ARGV.replace(original_argv)
   end
+
+  it 'skips validation when only the generator namespace remains in ARGV' do
+    expect(configuration_initializer).not_to be_nil
+
+    described_class.config.after_initialize_callbacks.clear
+
+    original_argv = ARGV.dup
+
+    stub_const('Rails::Generators', Module.new)
+    ARGV.replace(['verikloak:install'])
+
+    railtie = described_class.new
+    railtie.instance_eval(&configuration_initializer[1])
+
+    callback = described_class.config.after_initialize_callbacks.last
+    config_double = instance_double(Verikloak::Audience::Configuration)
+    allow(Verikloak::Audience).to receive(:config).and_return(config_double)
+    expect(config_double).not_to receive(:validate!)
+
+    callback.call
+  ensure
+    described_class.config.after_initialize_callbacks.clear
+    ARGV.replace(original_argv)
+  end
 end


### PR DESCRIPTION
## Summary
- allow the Railtie to skip configuration validation when the generator command appears only as `verikloak:install`, covering wrapper environments such as Docker Compose
- add a regression spec that exercises the stripped-ARGV case
- bump the gem version to 0.2.3 and document the fix in the changelog