### PR TITLE
Add generator for audience middleware insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- Rails generator `verikloak:audience:install` to create an initializer that inserts the audience middleware once the core Verikloak middleware is available.
+
 ## [0.2.5] - 2025-09-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.2.6] - 2025-09-23
 
 ### Added
 - Rails generator `verikloak:audience:install` to create an initializer that inserts the audience middleware once the core Verikloak middleware is available.
+
+### Changed
+- Improved warning message when core Verikloak middleware is not present in the Rails middleware stack.
+- Enhanced middleware insertion logic to provide clearer guidance on setup requirements.
 
 ## [0.2.5] - 2025-09-23
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-audience (0.2.5)
+    verikloak-audience (0.2.6)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.2.0, < 1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,17 @@ For the full error behaviour (response shapes, exception classes, logging hints)
 bundle add verikloak-audience
 ```
 
-In Rails applications, generate the initializer that inserts the middleware:
+In Rails applications, generate the initializer that automatically inserts the middleware:
 
 ```bash
 rails g verikloak:audience:install
 ```
 
-## Rack / Rails usage
+This creates `config/initializers/verikloak_audience.rb` that will insert the audience middleware after the core Verikloak middleware once it's available.
 
-Insert **after** `Verikloak::Middleware`:
+## Manual Rack / Rails setup
+
+Alternatively, you can manually insert **after** `Verikloak::Middleware`:
 
 ```ruby
 # config/application.rb

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ For the full error behaviour (response shapes, exception classes, logging hints)
 bundle add verikloak-audience
 ```
 
+In Rails applications, generate the initializer that inserts the middleware:
+
+```bash
+rails g verikloak:audience:install
+```
+
 ## Rack / Rails usage
 
 Insert **after** `Verikloak::Middleware`:

--- a/lib/generators/verikloak/audience/install/install_generator.rb
+++ b/lib/generators/verikloak/audience/install/install_generator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+begin
+  require 'rails/generators'
+  require 'rails/generators/base'
+rescue LoadError
+  # Allow the generator to be required without Rails.
+end
+
+module Verikloak
+  module Audience
+    module Generators
+      # Installs the verikloak audience middleware configuration into a Rails
+      # application. This generator creates an initializer that inserts the
+      # audience middleware after the core Verikloak middleware once it is
+      # available.
+      class InstallGenerator < (defined?(Rails::Generators::Base) ? Rails::Generators::Base : Object)
+        source_root File.expand_path('templates', __dir__) if respond_to?(:source_root)
+
+        def create_initializer
+          return unless respond_to?(:template, true)
+
+          template 'verikloak_audience.rb.tt', 'config/initializers/verikloak_audience.rb'
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/verikloak/audience/install/templates/verikloak_audience.rb.tt
+++ b/lib/generators/verikloak/audience/install/templates/verikloak_audience.rb.tt
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Insert the audience middleware after the core Verikloak middleware once it
+# has been loaded into the application.
+if defined?(Rails) && Rails.respond_to?(:application)
+  Verikloak::Audience::Railtie.insert_middleware(Rails.application)
+end

--- a/lib/verikloak/audience/version.rb
+++ b/lib/verikloak/audience/version.rb
@@ -4,6 +4,6 @@ module Verikloak
   module Audience
     # Current gem version.
     # @return [String]
-    VERSION = '0.2.5'
+    VERSION = '0.2.6'
   end
 end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+
+# Provide a lightweight stub for Rails::Generators::Base so the generator can
+# be required without pulling in Rails during the test suite.
+unless defined?(Rails::Generators::Base)
+  module Rails
+    module Generators
+      class Base
+        class << self
+          attr_reader :_source_root
+
+          def source_root(path = nil)
+            @_source_root = path if path
+            @_source_root
+          end
+
+          def desc(*) = nil
+          def argument(*) = nil
+          def class_option(*) = nil
+        end
+
+        attr_reader :destination_root
+
+        def initialize(args = [], options = {}, config = {})
+          @destination_root = config[:destination_root] || Dir.pwd
+        end
+
+        private
+
+        def template(source, destination)
+          source_path = File.expand_path(source, self.class.source_root)
+          destination_path = File.expand_path(destination, destination_root)
+          FileUtils.mkdir_p(File.dirname(destination_path))
+          FileUtils.cp(source_path, destination_path)
+        end
+      end
+    end
+  end
+end
+
+require 'generators/verikloak/audience/install/install_generator'
+
+RSpec.describe Verikloak::Audience::Generators::InstallGenerator do
+  let(:destination_root) { Dir.mktmpdir('verikloak_audience_generator') }
+
+  after do
+    FileUtils.remove_entry(destination_root) if File.directory?(destination_root)
+  end
+
+  it 'creates an initializer that delegates to the railtie insertion helper' do
+    generator = described_class.new([], {}, destination_root: destination_root)
+    generator.create_initializer
+
+    initializer_path = File.join(destination_root, 'config/initializers/verikloak_audience.rb')
+    expect(File).to exist(initializer_path)
+
+    contents = File.read(initializer_path)
+    expect(contents).to include('Verikloak::Audience::Railtie.insert_middleware(Rails.application)')
+  end
+end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -18,9 +18,17 @@ unless defined?(Rails::Generators::Base)
             @_source_root
           end
 
-          def desc(*) = nil
-          def argument(*) = nil
-          def class_option(*) = nil
+          def desc(*)
+            nil
+          end
+
+          def argument(*)
+            nil
+          end
+
+          def class_option(*)
+            nil
+          end
         end
 
         attr_reader :destination_root


### PR DESCRIPTION
## Summary
- add a `verikloak:audience:install` Rails generator that installs an initializer delegating middleware insertion to the railtie helper
- document the new generator in the README and changelog
- update the warning message to point developers to the generator when the core middleware is absent