### PR TITLE
Generator improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.1] - 2026-01-01
+
+### Added
+- **`:any_match` profile**: New audience validation profile that passes when at least one of the required audiences is present in the token.
+- **`skip_paths` configuration**: Skip audience validation for specific paths (e.g., health checks). Supports exact matches, prefix matches, wildcard patterns, and Regexp.
+- **Generator improvements**: Install generator now includes `Verikloak::Audience.configure` block with all four profiles documented.
+
+### Fixed
+- **Regexp support in `skip_paths`**: Fixed `NoMethodError` when passing Regexp patterns.
+- **Warning message accuracy**: Unconfigured warning now correctly states "ALL requests will be rejected with 403".
+- Configuration sync now happens before middleware insertion.
+
+### Changed
+- README now correctly describes that the Railtie automatically inserts the middleware.
+- Removed manual `insert_middleware` call from generated initializer (Railtie handles this automatically).
+
 ## [0.3.0] - 2026-01-01
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-audience (0.3.0)
+    verikloak-audience (0.3.1)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.3.0, < 1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For the full error behaviour (response shapes, exception classes, logging hints)
 |---------|---------|-----------------------------------------------------------|
 | `:strict_single` *(recommended)* | Requires `aud` to match `required_aud` exactly (order-insensitive, no extras). | APIs where audiences are cleanly separated. Logged suggestion when the observed `aud` already equals the configured list. |
 | `:allow_account` | Allows `account` in addition to required audiences (e.g. `["rails-api","account"]`). | SPA + API mixes where Keycloak always emits `account`. Suggested when strict mode fails and the log shows `profile=:allow_account`. |
+| `:any_match` | Passes when at least one of the required audiences is present. | Shared APIs where multiple clients may have overlapping audiences. More permissive than `:strict_single`. |
 | `:resource_or_aud` | Passes when `resource_access[client].roles` is present; otherwise falls back to `:allow_account`. | Services relying on resource roles. Suggested when logs output `profile=:resource_or_aud`. |
 
 ## Installation
@@ -30,13 +31,14 @@ For the full error behaviour (response shapes, exception classes, logging hints)
 bundle add verikloak-audience
 ```
 
-In Rails applications, generate the initializer that automatically inserts the middleware:
+In Rails applications, run the generator to create a configuration initializer:
 
 ```bash
 rails g verikloak:audience:install
 ```
 
-This creates `config/initializers/verikloak_audience.rb` that will insert the audience middleware after the core Verikloak middleware once it's available.
+This creates `config/initializers/verikloak_audience.rb` with configuration options.
+The middleware is automatically inserted by the Railtie after `Verikloak::Middleware`.
 
 ## Manual Rack / Rails setup
 
@@ -58,7 +60,7 @@ See [`examples/rack.ru`](examples/rack.ru) for a full Rack sample. In Rails, alw
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `profile` | Symbol | `:strict_single` | Profile selector. Accepts `:strict_single`, `:allow_account`, or `:resource_or_aud`. |
+| `profile` | Symbol | `:strict_single` | Profile selector. Accepts `:strict_single`, `:allow_account`, `:any_match`, or `:resource_or_aud`. |
 | `required_aud` | Array/String/Symbol | `[]` | Required audience values; coerced to an array internally. |
 | `resource_client` | String | `"rails-api"` | Keycloak client id used to look up `resource_access[client].roles`. |
 | `env_claims_key` | String | `"verikloak.user"` | Rack env key where verified claims are stored. |

--- a/lib/generators/verikloak/audience/install/templates/initializer.rb.erb
+++ b/lib/generators/verikloak/audience/install/templates/initializer.rb.erb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
-# Insert the audience middleware after the core Verikloak middleware once it
-# has been loaded into the application.
+# Verikloak Audience Configuration
 #
-# The Railtie's insert_middleware method includes internal guards to prevent
-# duplicate insertion when both the railtie initializer and this generated
-# initializer are loaded. This is safe to call multiple times.
-if defined?(Rails) && Rails.respond_to?(:application)
-  Verikloak::Audience::Railtie.insert_middleware(Rails.application)
+# Configure the audience validation profile and settings.
+# This middleware provides stricter audience validation than core Verikloak.
+#
+# The middleware is automatically inserted after Verikloak::Middleware by the
+# Railtie. No manual middleware insertion is required.
+#
+Verikloak::Audience.configure do |config|
+  # Audience validation profile
+  # :strict_single   - Only exact single audience match (default, recommended)
+  # :allow_account   - Allow "account" alongside your API audience
+  # :any_match       - At least one required audience is present (more permissive)
+  # :resource_or_aud - Check resource_access roles first, fallback to :allow_account
+  # config.profile = :strict_single
+
+  # Required audience(s) - synced from verikloak-rails automatically
+  # config.required_aud = ['rails-api']
+
+  # Skip paths for audience validation (synced from verikloak-rails automatically)
+  # config.skip_paths = %w[/up /health]
 end

--- a/lib/verikloak/audience/configuration.rb
+++ b/lib/verikloak/audience/configuration.rb
@@ -8,7 +8,7 @@ module Verikloak
     #
     # @!attribute [rw] profile
     #   The enforcement profile to use.
-    #   @return [:strict_single, :allow_account, :resource_or_aud]
+    #   @return [:strict_single, :allow_account, :any_match, :resource_or_aud]
     # @!attribute [rw] required_aud
     #   Required audience(s). Can be a String/Symbol or an Array of them.
     #   @return [Array<String,Symbol>, String, Symbol]
@@ -21,12 +21,16 @@ module Verikloak
     # @!attribute [rw] suggest_in_logs
     #   Whether to log a suggestion when audience validation fails.
     #   @return [Boolean]
+    # @!attribute [rw] skip_paths
+    #   Paths to skip audience validation for (e.g., health checks).
+    #   Synced from verikloak-rails when available.
+    #   @return [Array<String, Regexp>]
     class Configuration
       DEFAULT_RESOURCE_CLIENT = 'rails-api'
       DEFAULT_ENV_CLAIMS_KEY = 'verikloak.user'
 
       attr_accessor :profile, :required_aud, :resource_client,
-                    :suggest_in_logs
+                    :suggest_in_logs, :skip_paths
       attr_reader :env_claims_key
 
       # Create a configuration with safe defaults.
@@ -38,6 +42,7 @@ module Verikloak
         @resource_client = DEFAULT_RESOURCE_CLIENT
         self.env_claims_key = DEFAULT_ENV_CLAIMS_KEY
         @suggest_in_logs = true
+        @skip_paths      = []
       end
 
       # Ensure `dup` produces an independent copy.
@@ -51,6 +56,7 @@ module Verikloak
         @resource_client = safe_dup(source.resource_client)
         self.env_claims_key = safe_dup(source.env_claims_key)
         @suggest_in_logs = source.suggest_in_logs
+        @skip_paths      = source.skip_paths&.dup || []
       end
 
       # Coerce `required_aud` into an array of strings.

--- a/lib/verikloak/audience/railtie.rb
+++ b/lib/verikloak/audience/railtie.rb
@@ -266,10 +266,10 @@ module Verikloak
       end
 
       def self.skip_unconfigured_validation?
-        audiences_configured?
+        audiences_unconfigured?
       end
 
-      def self.audiences_configured?
+      def self.audiences_unconfigured?
         audiences = Verikloak::Audience.config.required_aud_list
 
         if audiences.empty?

--- a/lib/verikloak/audience/railtie.rb
+++ b/lib/verikloak/audience/railtie.rb
@@ -4,6 +4,177 @@ require 'rails/railtie'
 
 module Verikloak
   module Audience
+    # Warning messages for Railtie.
+    module RailtieWarnings
+      WARNING_MESSAGE = <<~MSG
+        [verikloak-audience] Skipping automatic middleware insertion because ::Verikloak::Middleware
+        is not present in the Rails middleware stack.
+
+        To enable verikloak-audience, first ensure that the core Verikloak middleware (`Verikloak::Middleware`)
+        is added to your Rails middleware stack. Once the core middleware is present, you can run
+        `rails g verikloak:audience:install` to generate the initializer for the audience middleware,
+        or manually add:
+
+          config.middleware.insert_after Verikloak::Middleware, Verikloak::Audience::Middleware
+
+        This warning will disappear once the core middleware is properly configured and the audience
+        middleware is inserted.
+      MSG
+
+      CORE_NOT_CONFIGURED_WARNING = <<~MSG
+        [verikloak-audience] Skipping automatic middleware insertion because verikloak-rails
+        is not fully configured (discovery_url is not set).
+
+        The audience middleware requires the core Verikloak middleware to be present in the stack.
+        Please configure verikloak-rails first by setting the discovery_url in your initializer.
+      MSG
+
+      UNCONFIGURED_WARNING = <<~MSG
+        [verikloak-audience] Skipping configuration validation because required_aud is not configured.
+
+        To use verikloak-audience, you must configure at least one required audience.
+        Run `rails g verikloak:audience:install` to generate the initializer, or add:
+
+          Verikloak::Audience.configure do |config|
+            config.required_aud = ['your-audience']
+          end
+
+        WARNING: Without this configuration, ALL requests will be rejected with 403.
+      MSG
+
+      def log_warning(message)
+        logger = (::Rails.logger if defined?(::Rails) && ::Rails.respond_to?(:logger))
+        logger ? logger.warn(message) : Kernel.warn(message)
+      end
+
+      def warn_core_not_configured = log_warning(CORE_NOT_CONFIGURED_WARNING)
+      def warn_missing_core_middleware = log_warning(WARNING_MESSAGE)
+      def warn_unconfigured = log_warning(UNCONFIGURED_WARNING)
+    end
+
+    # Helper methods for Railtie configuration sync.
+    module RailtieHelpers
+      include RailtieWarnings
+
+      def apply_verikloak_rails_configuration
+        rails_config = verikloak_rails_config
+        return unless rails_config
+
+        Verikloak::Audience.configure do |cfg|
+          sync_env_claims_key(cfg, rails_config)
+          sync_required_aud(cfg, rails_config)
+          sync_resource_client(cfg, rails_config)
+          sync_skip_paths(cfg, rails_config)
+        end
+      end
+
+      def discovery_url_configured?(value)
+        return false unless value
+        return !value.blank? if value.respond_to?(:blank?)
+        return !value.empty? if value.respond_to?(:empty?)
+
+        true
+      end
+
+      def middleware_not_found_error?(error)
+        return true if error.class.name.to_s.include?('MiddlewareNotFound')
+
+        message = error.message.to_s
+        message.include?('No such middleware') ||
+          message.include?('does not exist') ||
+          message.match?(/middleware.*not found/i)
+      end
+
+      def verikloak_install_generator?(command)
+        return false unless command.is_a?(String)
+
+        command.start_with?('verikloak:') && command.end_with?(':install')
+      end
+
+      def first_cli_tokens
+        tokens = []
+        ARGV.each do |arg|
+          next if arg.start_with?('-') || arg == 'rails'
+
+          tokens << arg
+          break if tokens.size >= 2
+        end
+        tokens
+      end
+
+      private
+
+      def verikloak_rails_config
+        return unless defined?(::Verikloak::Rails)
+        return unless ::Verikloak::Rails.respond_to?(:config)
+
+        ::Verikloak::Rails.config
+      rescue StandardError
+        nil
+      end
+
+      def sync_env_claims_key(cfg, rails_config)
+        return unless rails_config.respond_to?(:user_env_key)
+
+        user_key = rails_config.user_env_key
+        return if blank?(user_key)
+
+        current = cfg.env_claims_key
+        return unless current.nil? || current == Verikloak::Audience::Configuration::DEFAULT_ENV_CLAIMS_KEY
+
+        cfg.env_claims_key = user_key
+      end
+
+      def sync_required_aud(cfg, rails_config)
+        return unless cfg_required_aud_blank?(cfg)
+        return unless rails_config.respond_to?(:audience)
+
+        audiences = normalized_audiences(rails_config.audience)
+        return if audiences.empty?
+
+        cfg.required_aud = audiences.size == 1 ? audiences.first : audiences
+      end
+
+      def sync_resource_client(cfg, rails_config)
+        return unless rails_config.respond_to?(:audience)
+
+        audiences = normalized_audiences(rails_config.audience)
+        return unless audiences.size == 1
+
+        current_client = cfg.resource_client
+        unless blank?(current_client) || current_client == Verikloak::Audience::Configuration::DEFAULT_RESOURCE_CLIENT
+          return
+        end
+
+        cfg.resource_client = audiences.first
+      end
+
+      def sync_skip_paths(cfg, rails_config)
+        return unless rails_config.respond_to?(:skip_paths)
+
+        paths = rails_config.skip_paths
+        return if paths.nil?
+        return unless cfg.skip_paths.nil? || cfg.skip_paths.empty?
+
+        cfg.skip_paths = Array(paths).compact
+      end
+
+      def cfg_required_aud_blank?(cfg) = value_blank?(cfg.required_aud)
+
+      def value_blank?(value)
+        return true if value.nil?
+        return true if value.respond_to?(:empty?) && value.empty?
+
+        value.to_s.empty?
+      end
+
+      alias blank? value_blank?
+
+      def normalized_audiences(source)
+        Array(source).compact.map(&:to_s).reject(&:empty?)
+      end
+    end
+
     # Rails integration for verikloak-audience.
     #
     # This Railtie automatically inserts {Verikloak::Audience::Middleware}
@@ -24,305 +195,96 @@ module Verikloak
     #     env_claims_key: 'verikloak.user',
     #     suggest_in_logs: true
     class Railtie < ::Rails::Railtie
-      # Adds the audience middleware after the core Verikloak middleware
-      # when available.
-      #
-      # @param app [Rails::Application] the Rails application instance
+      class << self
+        attr_accessor :middleware_insertion_attempted, :unconfigured_warning_emitted
+
+        include RailtieHelpers
+      end
+
+      @middleware_insertion_attempted = false
+      @unconfigured_warning_emitted = false
+
       initializer 'verikloak_audience.middleware',
                   after: 'verikloak.configure',
                   before: :build_middleware_stack do |app|
-        # Insert automatically after core verikloak if present
+        self.class.apply_verikloak_rails_configuration
         self.class.insert_middleware(app)
       end
 
       initializer 'verikloak_audience.configuration' do
         config.after_initialize do
-          self.class.apply_verikloak_rails_configuration
           next if Verikloak::Audience::Railtie.skip_configuration_validation?
+          next if Verikloak::Audience::Railtie.skip_unconfigured_validation?
 
           Verikloak::Audience.config.validate!
         end
       end
 
-      # Tracks whether middleware insertion has been attempted to prevent
-      # duplicate insertions when both railtie and generator initializer run.
-      # In Rails 8.x+, middleware operations may be queued and `include?` may
-      # not reflect pending insertions, so we use this flag as an additional
-      # safeguard.
-      @middleware_insertion_attempted = false
+      COMMANDS_SKIPPING_VALIDATION = %w[generate g destroy d].freeze
 
-      class << self
-        attr_accessor :middleware_insertion_attempted
-      end
-
-      # Performs the insertion into the middleware stack when the core
-      # Verikloak middleware is available and already present. Extracted for
-      # testability without requiring a full Rails boot process.
-      #
-      # Insert the audience middleware after the base Verikloak middleware when
-      # both are available on the stack.
-      #
-      # In Rails 8.x+, middleware stack operations may be queued rather than
-      # immediately applied, so `include?` checks may return false even when
-      # the middleware will be inserted. We use `insert_after` with exception
-      # handling to gracefully handle this case.
-      #
-      # @param app [#middleware] An object exposing a Rack middleware stack via `#middleware`.
-      # @return [void]
       def self.insert_middleware(app)
         return unless defined?(::Verikloak::Middleware)
 
-        # Skip if we have already attempted insertion (handles Rails 8+ queued operations)
+        if defined?(::Verikloak::Rails) && ::Verikloak::Rails.respond_to?(:config)
+          discovery_url = ::Verikloak::Rails.config.discovery_url
+          unless discovery_url_configured?(discovery_url)
+            warn_core_not_configured
+            return
+          end
+        end
+
         return if middleware_insertion_attempted
 
-        # Use app.config.middleware for queued operations in Rails 8.x+
-        # This ensures the insert_after operation is queued and applied during
-        # build_middleware_stack, maintaining proper ordering with verikloak-rails
         middleware_stack = app.respond_to?(:config) ? app.config.middleware : app.middleware
 
-        # Skip if already present (avoid duplicate insertion)
-        if middleware_stack.respond_to?(:include?) &&
-           middleware_stack.include?(::Verikloak::Audience::Middleware)
+        if middleware_stack.respond_to?(:include?) && middleware_stack.include?(::Verikloak::Audience::Middleware)
           return
         end
 
-        # Mark as attempted before insertion to prevent concurrent/subsequent calls
         self.middleware_insertion_attempted = true
 
-        # Attempt to insert after the core Verikloak middleware.
-        # In Rails 8.x+, the middleware may be queued but not yet visible via include?,
-        # so we try the insertion and handle any exceptions gracefully.
         begin
           middleware_stack.insert_after ::Verikloak::Middleware, ::Verikloak::Audience::Middleware
         rescue StandardError => e
-          # Handle middleware not found errors (varies by Rails version):
-          # - Rails 8+: RuntimeError with "No such middleware" message
-          # - Earlier: ActionDispatch::MiddlewareStack::MiddlewareNotFound
           raise unless middleware_not_found_error?(e)
 
           warn_missing_core_middleware
         end
       end
 
-      # Determines if the given exception indicates a middleware not found error.
-      # This handles variations across Rails versions:
-      # - Rails 8+: RuntimeError with "No such middleware" message
-      # - Rails 7 and earlier: ActionDispatch::MiddlewareStack::MiddlewareNotFound
-      #
-      # @param error [StandardError] the exception to check
-      # @return [Boolean] true if the error indicates missing middleware
-      def self.middleware_not_found_error?(error)
-        # Check exception class name (works for Rails 7's MiddlewareNotFound)
-        return true if error.class.name.to_s.include?('MiddlewareNotFound')
-
-        # Check message patterns for Rails 8+ RuntimeError
-        message = error.message.to_s
-        message.include?('No such middleware') ||
-          message.include?('does not exist') ||
-          message.match?(/middleware.*not found/i)
-      end
-
-      # Resets the insertion flag. Primarily used for testing to allow
-      # multiple insertion attempts within the same process.
-      #
-      # @return [void]
       def self.reset_middleware_insertion_flag!
         self.middleware_insertion_attempted = false
       end
 
-      WARNING_MESSAGE = <<~MSG
-        [verikloak-audience] Skipping automatic middleware insertion because ::Verikloak::Middleware
-        is not present in the Rails middleware stack.
-
-        To enable verikloak-audience, first ensure that the core Verikloak middleware (`Verikloak::Middleware`)
-        is added to your Rails middleware stack. Once the core middleware is present, you can run
-        `rails g verikloak:audience:install` to generate the initializer for the audience middleware,
-        or manually add:
-
-          config.middleware.insert_after Verikloak::Middleware, Verikloak::Audience::Middleware
-
-        This warning will disappear once the core middleware is properly configured and the audience
-        middleware is inserted.
-      MSG
-
-      # Logs a warning message when the core Verikloak middleware is missing
-      # from the Rails middleware stack. Uses the Rails logger if available,
-      # otherwise falls back to Kernel.warn for output.
-      #
-      # This method is called when automatic middleware insertion is skipped
-      # due to the absence of the required core middleware.
-      #
-      # @return [void]
-      def self.warn_missing_core_middleware
-        logger = (::Rails.logger if defined?(::Rails) && ::Rails.respond_to?(:logger))
-
-        if logger
-          logger.warn(WARNING_MESSAGE)
-        else
-          Kernel.warn(WARNING_MESSAGE)
-        end
-      end
-
-      # Rails short commands (`g`, `d`) are stripped from ARGV fairly early in
-      # the boot process. Treat `verikloak:*:install` generators as safe so they
-      # can run before configuration files exist.
-      COMMANDS_SKIPPING_VALIDATION = %w[generate g destroy d].freeze
-
-      # Detect whether Rails is currently executing a generator-style command.
-      # Generators boot the application before configuration exists, so we
-      # temporarily skip validation to let the install task complete.
-      #
-      # @return [Boolean]
       def self.skip_configuration_validation?
         tokens = first_cli_tokens
         return false if tokens.empty?
 
-        command = tokens.first
-        return true if COMMANDS_SKIPPING_VALIDATION.include?(command)
+        return true if COMMANDS_SKIPPING_VALIDATION.include?(tokens.first)
 
         tokens.any? { |token| verikloak_install_generator?(token) }
       end
 
-      # Capture the first non-option arguments passed to the Rails CLI,
-      # ignoring wrapper tokens such as "rails". Only the first two tokens are
-      # relevant for generator detection, so we keep the return list short.
-      #
-      # @return [Array<String>] ordered CLI tokens that may signal a generator
-      def self.first_cli_tokens
-        tokens = []
-
-        ARGV.each do |arg|
-          next if arg.start_with?('-')
-          next if arg == 'rails'
-
-          tokens << arg
-          break if tokens.size >= 2
-        end
-
-        tokens
+      def self.skip_unconfigured_validation?
+        audiences_configured?
       end
 
-      # Detect whether the provided CLI token refers to a Verikloak install
-      # generator (e.g. `verikloak:install`, `verikloak:pundit:install`).
-      #
-      # @param command [String, nil] first non-option argument from ARGV
-      # @return [Boolean]
-      def self.verikloak_install_generator?(command)
-        return false unless command.is_a?(String)
+      def self.audiences_configured?
+        audiences = Verikloak::Audience.config.required_aud_list
 
-        command.start_with?('verikloak:') && command.end_with?(':install')
+        if audiences.empty?
+          warn_unconfigured_once
+          return true
+        end
+
+        false
       end
 
-      class << self
-        # Synchronize configuration with verikloak-rails when it is present.
-        # Aligns env_claims_key, required_aud, and resource_client defaults so
-        # that both gems operate on the same Rack env payload and audience list.
-        #
-        # @return [void]
-        def apply_verikloak_rails_configuration
-          rails_config = verikloak_rails_config
-          return unless rails_config
+      def self.warn_unconfigured_once
+        return if unconfigured_warning_emitted
 
-          Verikloak::Audience.configure do |cfg|
-            sync_env_claims_key(cfg, rails_config)
-            sync_required_aud(cfg, rails_config)
-            sync_resource_client(cfg, rails_config)
-          end
-        end
-
-        private
-
-        # Resolve the verikloak-rails configuration object if the gem is loaded.
-        #
-        # @return [Verikloak::Rails::Configuration, nil]
-        def verikloak_rails_config
-          return unless defined?(::Verikloak::Rails)
-          return unless ::Verikloak::Rails.respond_to?(:config)
-
-          ::Verikloak::Rails.config
-        rescue StandardError
-          nil
-        end
-
-        # Align the environment claims key with the one configured in verikloak-rails.
-        #
-        # @param cfg [Verikloak::Audience::Configuration]
-        # @param rails_config [Verikloak::Rails::Configuration]
-        # @return [void]
-        def sync_env_claims_key(cfg, rails_config)
-          return unless rails_config.respond_to?(:user_env_key)
-
-          user_key = rails_config.user_env_key
-          return if blank?(user_key)
-
-          current = cfg.env_claims_key
-          return unless current.nil? || current == Verikloak::Audience::Configuration::DEFAULT_ENV_CLAIMS_KEY
-
-          cfg.env_claims_key = user_key
-        end
-
-        # Populate required audiences from the verikloak-rails configuration when absent.
-        #
-        # @param cfg [Verikloak::Audience::Configuration]
-        # @param rails_config [Verikloak::Rails::Configuration]
-        # @return [void]
-        def sync_required_aud(cfg, rails_config)
-          return unless cfg_required_aud_blank?(cfg)
-          return unless rails_config.respond_to?(:audience)
-
-          audiences = normalized_audiences(rails_config.audience)
-          return if audiences.empty?
-
-          cfg.required_aud = audiences.size == 1 ? audiences.first : audiences
-        end
-
-        # Infer the resource client based on the configured audience when possible.
-        #
-        # @param cfg [Verikloak::Audience::Configuration]
-        # @param rails_config [Verikloak::Rails::Configuration]
-        # @return [void]
-        def sync_resource_client(cfg, rails_config)
-          return unless rails_config.respond_to?(:audience)
-
-          audiences = normalized_audiences(rails_config.audience)
-          return unless audiences.size == 1
-
-          current_client = cfg.resource_client
-          unless blank?(current_client) || current_client == Verikloak::Audience::Configuration::DEFAULT_RESOURCE_CLIENT
-            return
-          end
-
-          cfg.resource_client = audiences.first
-        end
-
-        # Determine whether the audience configuration is effectively empty.
-        #
-        # @param cfg [Verikloak::Audience::Configuration]
-        # @return [Boolean]
-        def cfg_required_aud_blank?(cfg)
-          value_blank?(cfg.required_aud)
-        end
-
-        # Generic blank? helper that tolerates nil, empty, or blank-ish values.
-        #
-        # @param value [Object]
-        # @return [Boolean]
-        def value_blank?(value)
-          return true if value.nil?
-          return true if value.respond_to?(:empty?) && value.empty?
-
-          value.to_s.empty?
-        end
-
-        alias blank? value_blank?
-
-        # Coerce the given source into an array of non-empty string audiences.
-        #
-        # @param source [Object]
-        # @return [Array<String>]
-        def normalized_audiences(source)
-          Array(source).compact.map(&:to_s).reject(&:empty?)
-        end
+        self.unconfigured_warning_emitted = true
+        warn_unconfigured
       end
     end
   end

--- a/lib/verikloak/audience/version.rb
+++ b/lib/verikloak/audience/version.rb
@@ -4,6 +4,6 @@ module Verikloak
   module Audience
     # Current gem version.
     # @return [String]
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/spec/audience_checker_spec.rb
+++ b/spec/audience_checker_spec.rb
@@ -25,6 +25,29 @@ RSpec.describe Verikloak::Audience::Checker do
     expect(described_class.ok?(claims, cfg)).to be true
   end
 
+  it "any_match passes when at least one required audience is present" do
+    cfg.profile = :any_match
+    cfg.required_aud = ["rails-api", "other-api"]
+
+    # One match is sufficient
+    expect(described_class.ok?({ "aud" => ["rails-api"] }, cfg)).to be true
+    expect(described_class.ok?({ "aud" => ["other-api"] }, cfg)).to be true
+    expect(described_class.ok?({ "aud" => ["rails-api", "other-api"] }, cfg)).to be true
+
+    # Extra audiences are allowed
+    expect(described_class.ok?({ "aud" => ["rails-api", "account", "extra"] }, cfg)).to be true
+
+    # No match fails
+    expect(described_class.ok?({ "aud" => ["unrelated"] }, cfg)).to be false
+    expect(described_class.ok?({ "aud" => [] }, cfg)).to be false
+  end
+
+  it "any_match returns false when required_aud is empty" do
+    cfg.profile = :any_match
+    cfg.required_aud = []
+    expect(described_class.ok?({ "aud" => ["anything"] }, cfg)).to be false
+  end
+
   it "strict_single returns false when required_aud is empty" do
     cfg.profile = :strict_single
     cfg.required_aud = []

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -65,10 +65,19 @@ RSpec.describe 'Verikloak::Audience::Generators::InstallGenerator' do
         expect(File).to exist(path)
         
         initializer_content = File.read(path)
-        expect(initializer_content).to include('Verikloak::Audience::Railtie')
-        expect(initializer_content).to include('Verikloak::Audience::Railtie.insert_middleware')
-        expect(initializer_content).to include('Rails.application')
         expect(initializer_content).to include('frozen_string_literal: true')
+        # Configuration block
+        expect(initializer_content).to include('Verikloak::Audience.configure do |config|')
+        expect(initializer_content).to include('config.profile')
+        expect(initializer_content).to include(':strict_single')
+        expect(initializer_content).to include(':allow_account')
+        expect(initializer_content).to include(':any_match')
+        # Railtie auto-insertion note
+        expect(initializer_content).to include('automatically inserted')
+        expect(initializer_content).to include('Railtie')
+        # Should NOT include manual middleware insertion
+        expect(initializer_content).not_to include('insert_middleware')
+        expect(initializer_content).not_to include('Rails.application)')
       end
     end
   end
@@ -81,9 +90,12 @@ RSpec.describe 'Verikloak::Audience::Generators::InstallGenerator' do
 
         initializer_content = File.read('config/initializers/verikloak_audience.rb')
 
-        expect(initializer_content).to include('defined?(Rails)')
-        expect(initializer_content).to include('Rails.respond_to?(:application)')
         expect(initializer_content).to include('frozen_string_literal: true')
+        # Configuration documentation
+        expect(initializer_content).to include('config.required_aud')
+        expect(initializer_content).to include('config.skip_paths')
+        # No manual middleware insertion required
+        expect(initializer_content).not_to include('defined?(Rails)')
       end
     end
   end

--- a/spec/middleware_require_spec.rb
+++ b/spec/middleware_require_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe "Verikloak::Audience::Middleware standalone require" do
   it "middleware validates configuration when loaded standalone" do
     app = ->(_env) { [200, {}, ["ok"]] }
 
+    # Stub skip_unconfigured_validation? to return false so validation runs
+    railtie = Class.new do
+      def self.skip_configuration_validation?
+        false
+      end
+
+      def self.skip_unconfigured_validation?
+        false
+      end
+    end
+    stub_const("Verikloak::Audience::Railtie", railtie)
+
     expect {
       Verikloak::Audience::Middleware.new(app, required_aud: [])
     }.to raise_error(Verikloak::Audience::ConfigurationError, /required_aud must include at least one audience/)


### PR DESCRIPTION
### Added
- **`:any_match` profile**: New audience validation profile that passes when at least one of the required audiences is present in the token.
- **`skip_paths` configuration**: Skip audience validation for specific paths (e.g., health checks). Supports exact matches, prefix matches, wildcard patterns, and Regexp.
- **Generator improvements**: Install generator now includes `Verikloak::Audience.configure` block with all four profiles documented.

### Fixed
- **Regexp support in `skip_paths`**: Fixed `NoMethodError` when passing Regexp patterns.
- **Warning message accuracy**: Unconfigured warning now correctly states "ALL requests will be rejected with 403".
- Configuration sync now happens before middleware insertion.

### Changed
- README now correctly describes that the Railtie automatically inserts the middleware.
- Removed manual `insert_middleware` call from generated initializer (Railtie handles this automatically).