### PR TITLE
Update libs and logics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - 2026-02-15
 
+### Added
+- **`Audience.reset!`**: New `reset!` class method for test teardown to prevent configuration leakage between examples
+
 ### Changed
 - Error responses now delegate to `Verikloak::ErrorResponse.build` for RFC 6750-compliant JSON output with `WWW-Authenticate` header
 - Skip-path matching now uses shared `Verikloak::SkipPathMatcher` from core gem (removes duplicated logic)
 - Error class hierarchy unified: `Verikloak::Audience::Error` now inherits from `Verikloak::Error`
 - **BREAKING**: Minimum `verikloak` dependency raised to `>= 0.4.1, < 1.0.0`
+- **BREAKING**: `skip_paths` prefix matching now requires explicit `/*` suffix (e.g. `'/rails/health/*'` instead of `'/rails/health'`). Exact path strings without `/*` are treated as exact matches only. Regexp patterns are unaffected.
 - Dev dependency `rspec` pinned to `~> 3.13`, `rubocop-rspec` pinned to `~> 3.9`
 
 ### Fixed
 - **`normalize_claims` observability**: `rescue StandardError` now captures the exception and emits a `warn` when `$DEBUG` is enabled, improving debuggability of malformed claims
-- **`Audience.reset!` added**: New `reset!` class method for test teardown to prevent configuration leakage between examples
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0] - 2026-02-15
+
+### Changed
+- Error responses now delegate to `Verikloak::ErrorResponse.build` for RFC 6750-compliant JSON output with `WWW-Authenticate` header
+- Skip-path matching now uses shared `Verikloak::SkipPathMatcher` from core gem (removes duplicated logic)
+- Error class hierarchy unified: `Verikloak::Audience::Error` now inherits from `Verikloak::Error`
+- **BREAKING**: Minimum `verikloak` dependency raised to `>= 0.4.1, < 1.0.0`
+- Dev dependency `rspec` pinned to `~> 3.13`, `rubocop-rspec` pinned to `~> 3.9`
+
+### Fixed
+- **`normalize_claims` observability**: `rescue StandardError` now captures the exception and emits a `warn` when `$DEBUG` is enabled, improving debuggability of malformed claims
+- **`Audience.reset!` added**: New `reset!` class method for test teardown to prevent configuration leakage between examples
+
+---
+
 ## [0.3.1] - 2026-01-01
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ gemspec
 group :development, :test do
   gem 'rack-test'
   gem 'rake'
-  gem 'rspec'
+  gem 'rspec', '~> 3.13'
   gem 'rubocop', require: false
   gem 'rubocop-rake', require: false
-  gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec', '~> 3.9', require: false
 end
 
 # Security auditing for dependencies in development/CI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,29 @@
 PATH
   remote: .
   specs:
-    verikloak-audience (0.3.1)
+    verikloak-audience (0.4.0)
       rack (>= 2.2, < 4.0)
-      verikloak (>= 0.3.0, < 1.0.0)
+      verikloak (>= 0.4.1, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
     base64 (0.3.0)
-    bundler-audit (0.9.2)
-      bundler (>= 1.2.0, < 3)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
       thor (~> 1.0)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
-    faraday-retry (2.3.2)
+    faraday-retry (2.4.0)
       faraday (~> 2.0)
-    json (2.15.2)
+    json (2.18.1)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -32,16 +32,16 @@ GEM
     net-http (0.6.0)
       uri
     parallel (1.27.0)
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
-    prism (1.6.0)
+    prism (1.9.0)
     racc (1.8.1)
     rack (3.2.4)
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)
-    rake (13.3.0)
+    rake (13.3.1)
     regexp_parser (2.11.3)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -58,7 +58,7 @@ GEM
     rspec-support (3.13.6)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.81.7)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -66,18 +66,18 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.47.1, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.47.1)
+    rubocop-ast (1.49.0)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
+      prism (~> 1.7)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
-    rubocop-rspec (3.7.0)
+    rubocop-rspec (3.9.0)
       lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
+      rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -85,15 +85,15 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    thor (1.4.0)
+    thor (1.5.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
     uri (1.0.4)
-    verikloak (0.3.0)
-      faraday (>= 2.0, < 3.0)
-      faraday-retry (>= 2.0, < 3.0)
-      json (~> 2.6)
+    verikloak (0.4.1)
+      faraday (>= 2.14.1, < 3.0)
+      faraday-retry (>= 2.4.0, < 3.0)
+      json (~> 2.18)
       jwt (>= 2.7, < 4.0)
 
 PLATFORMS
@@ -105,11 +105,11 @@ DEPENDENCIES
   bundler-audit
   rack-test
   rake
-  rspec
+  rspec (~> 3.13)
   rspec_junit_formatter
   rubocop
   rubocop-rake
-  rubocop-rspec
+  rubocop-rspec (~> 3.9)
   simplecov
   verikloak-audience!
 

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -4,7 +4,8 @@ FROM ruby:3.4.8-alpine3.23
 # Base packages:
 # - Runtime: bash (for CI commands), git (bundler-audit update), openssl (runtime lib), tzdata, libstdc++
 # - Build deps: build-base, openssl-dev (for native extensions) — removed after bundle install
-RUN apk add --no-cache \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
       bash \
       git \
       openssl \
@@ -33,13 +34,12 @@ RUN bundle install
 # App source
 COPY . .
 
-# Remove build dependencies to slim the image
-RUN apk del .build-deps
-
 # Run as non-root for safety in CI/dev, and match host UID/GID for bind-mount write access
 ARG UID=1000
 ARG GID=1000
 RUN addgroup -S -g $GID app \
     && adduser -S -u $UID -G app app \
-    && chown -R app:app /app
+    && chown -R app:app /app \
+    && chown -R app:app /usr/local/bundle
+
 USER app

--- a/lib/verikloak/audience.rb
+++ b/lib/verikloak/audience.rb
@@ -34,6 +34,14 @@ module Verikloak
       def config
         @config ||= Configuration.new
       end
+
+      # Reset configuration to defaults.
+      # Intended for test teardown to prevent leakage between examples.
+      #
+      # @return [void]
+      def reset!
+        @config = nil
+      end
     end
   end
 end

--- a/lib/verikloak/audience/checker.rb
+++ b/lib/verikloak/audience/checker.rb
@@ -129,7 +129,8 @@ module Verikloak
         end
 
         {}
-      rescue StandardError
+      rescue StandardError => e
+        warn "[Verikloak::Audience] normalize_claims failed: #{e.class}: #{e.message}" if $DEBUG
         {}
       end
       module_function :normalize_claims

--- a/lib/verikloak/audience/errors.rb
+++ b/lib/verikloak/audience/errors.rb
@@ -8,12 +8,9 @@ module Verikloak
     # Inherits from {Verikloak::Error} so that `rescue Verikloak::Error` catches all
     # Verikloak gem errors uniformly.
     #
-    # @!attribute [r] code
-    #   Machine-friendly error code (e.g. "insufficient_audience").
-    #   @return [String]
-    # @!attribute [r] http_status
-    #   HTTP status code associated with the error.
-    #   @return [Integer]
+    # Inherits `code` and `http_status` accessors from {Verikloak::Error}.
+    # The parent class defines `attr_reader :code, :http_status` and accepts
+    # `code:` / `http_status:` keyword arguments in its initializer.
     class Error < Verikloak::Error
       # @param msg [String] human-readable error message
       # @param code [String] machine-friendly error code

--- a/lib/verikloak/audience/errors.rb
+++ b/lib/verikloak/audience/errors.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require 'verikloak/errors'
+
 module Verikloak
   module Audience
     # Base error for audience failures.
+    # Inherits from {Verikloak::Error} so that `rescue Verikloak::Error` catches all
+    # Verikloak gem errors uniformly.
     #
     # @!attribute [r] code
     #   Machine-friendly error code (e.g. "insufficient_audience").
@@ -10,16 +14,12 @@ module Verikloak
     # @!attribute [r] http_status
     #   HTTP status code associated with the error.
     #   @return [Integer]
-    class Error < StandardError
-      attr_reader :code, :http_status
-
+    class Error < Verikloak::Error
       # @param msg [String] human-readable error message
       # @param code [String] machine-friendly error code
       # @param http_status [Integer] associated HTTP status
       def initialize(msg = 'audience error', code: 'audience_error', http_status: 403)
-        super(msg)
-        @code = code
-        @http_status = http_status
+        super
       end
     end
 

--- a/lib/verikloak/audience/middleware.rb
+++ b/lib/verikloak/audience/middleware.rb
@@ -5,6 +5,7 @@ require 'verikloak/audience'
 require 'verikloak/audience/configuration'
 require 'verikloak/audience/checker'
 require 'verikloak/audience/errors'
+require 'verikloak/skip_path_matcher'
 
 module Verikloak
   module Audience
@@ -13,6 +14,8 @@ module Verikloak
     # Place this middleware after the core {::Verikloak::Middleware} so that
     # verified token claims are already available in the Rack env.
     class Middleware
+      include Verikloak::SkipPathMatcher
+
       # @param app [#call] next Rack application
       # @param opts [Hash] configuration overrides (see {Configuration})
       # @option opts [Symbol] :profile (:strict_single, :allow_account, :any_match, :resource_or_aud)
@@ -26,6 +29,7 @@ module Verikloak
         @config = Verikloak::Audience.config.dup
         apply_overrides!(opts)
         @config.validate! unless skip_validation?
+        compile_skip_paths(@config.skip_paths || [])
       end
 
       # Evaluate the request against the audience profile.
@@ -34,7 +38,8 @@ module Verikloak
       # @return [Array(Integer, Hash, #each)] Rack response triple
       def call(env)
         # Skip audience validation for configured paths (e.g., health checks)
-        return @app.call(env) if skip_path?(env)
+        path = env['PATH_INFO'] || env['REQUEST_PATH'] || ''
+        return @app.call(env) if skip?(path)
 
         env_key = @config.env_claims_key
         claims = env[env_key] || env[env_key&.to_sym] || {}
@@ -47,43 +52,15 @@ module Verikloak
                       "[verikloak-audience] insufficient_audience; suggestion profile=:#{suggestion} aud=#{aud_view}")
         end
 
-        body = { error: 'insufficient_audience',
-                 message: "Audience not acceptable for profile #{@config.profile}" }.to_json
-        headers = { 'Content-Type' => 'application/json' }
-        [403, headers, [body]]
+        require 'verikloak/error_response'
+        Verikloak::ErrorResponse.build(
+          code: 'insufficient_audience',
+          message: "Audience not acceptable for profile #{@config.profile}",
+          status: 403
+        )
       end
 
       private
-
-      # Check if the current request path should skip audience validation.
-      #
-      # @param env [Hash] Rack environment
-      # @return [Boolean]
-      def skip_path?(env)
-        paths = @config.skip_paths
-        return false if paths.nil? || paths.empty?
-
-        request_path = env['PATH_INFO'] || env['REQUEST_PATH'] || ''
-        paths.any? { |pattern| path_matches?(request_path, pattern) }
-      end
-
-      # Determine if a request path matches the given pattern.
-      # Supports exact matches and prefix matches (pattern ending with *).
-      #
-      # @param request_path [String]
-      # @param pattern [String, Regexp]
-      # @return [Boolean]
-      def path_matches?(request_path, pattern)
-        return false if pattern.nil?
-        return request_path.match?(pattern) if pattern.is_a?(Regexp)
-        return false if pattern.empty?
-
-        if pattern.end_with?('*')
-          request_path.start_with?(pattern.chomp('*'))
-        else
-          request_path == pattern || request_path.start_with?("#{pattern}/")
-        end
-      end
 
       # Apply provided options to the configuration instance.
       #

--- a/lib/verikloak/audience/middleware.rb
+++ b/lib/verikloak/audience/middleware.rb
@@ -5,6 +5,7 @@ require 'verikloak/audience'
 require 'verikloak/audience/configuration'
 require 'verikloak/audience/checker'
 require 'verikloak/audience/errors'
+require 'verikloak/error_response'
 require 'verikloak/skip_path_matcher'
 
 module Verikloak
@@ -52,7 +53,6 @@ module Verikloak
                       "[verikloak-audience] insufficient_audience; suggestion profile=:#{suggestion} aud=#{aud_view}")
         end
 
-        require 'verikloak/error_response'
         Verikloak::ErrorResponse.build(
           code: 'insufficient_audience',
           message: "Audience not acceptable for profile #{@config.profile}",

--- a/lib/verikloak/audience/version.rb
+++ b/lib/verikloak/audience/version.rb
@@ -4,6 +4,6 @@ module Verikloak
   module Audience
     # Current gem version.
     # @return [String]
-    VERSION = '0.3.1'
+    VERSION = '0.4.0'
   end
 end

--- a/spec/audience_reset_spec.rb
+++ b/spec/audience_reset_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Verikloak::Audience.reset!" do
+  after { Verikloak::Audience.reset! }
+
+  it "resets configuration to defaults" do
+    Verikloak::Audience.configure do |cfg|
+      cfg.required_aud = ["custom-api"]
+      cfg.profile = :any_match
+      cfg.resource_client = "custom-client"
+    end
+
+    expect(Verikloak::Audience.config.required_aud).to eq(["custom-api"])
+    expect(Verikloak::Audience.config.profile).to eq(:any_match)
+
+    Verikloak::Audience.reset!
+
+    config = Verikloak::Audience.config
+    expect(config.required_aud).to eq(Verikloak::Audience::Configuration.new.required_aud)
+    expect(config.profile).to eq(Verikloak::Audience::Configuration.new.profile)
+    expect(config.resource_client).to eq(Verikloak::Audience::Configuration::DEFAULT_RESOURCE_CLIENT)
+  end
+
+  it "prevents configuration leakage between examples (part 1: set)" do
+    Verikloak::Audience.configure { |c| c.required_aud = ["leaked-api"] }
+    expect(Verikloak::Audience.config.required_aud).to eq(["leaked-api"])
+  end
+
+  it "prevents configuration leakage between examples (part 2: verify)" do
+    # after block in part 1 called reset!, so config should be fresh defaults
+    expect(Verikloak::Audience.config.required_aud).not_to eq(["leaked-api"])
+  end
+end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Verikloak::Audience::Middleware do
     end
 
     it "skips audience validation for path prefix matches" do
-      app = build_app(profile: :strict_single, required_aud: ["rails-api"], env_claims_key: "claims", skip_paths: ["/rails/health"])
+      app = build_app(profile: :strict_single, required_aud: ["rails-api"], env_claims_key: "claims", skip_paths: ["/rails/health/*"])
       res = Rack::MockRequest.new(app).get("/rails/health/check", {})
       expect(res.status).to eq 200
     end

--- a/verikloak-audience.gemspec
+++ b/verikloak-audience.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.add_dependency 'verikloak', '>= 0.3.0', '< 1.0.0'
+  spec.add_dependency 'verikloak', '>= 0.4.1', '< 1.0.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
### Changed
- Error responses now delegate to `Verikloak::ErrorResponse.build` for RFC 6750-compliant JSON output with `WWW-Authenticate` header
- Skip-path matching now uses shared `Verikloak::SkipPathMatcher` from core gem (removes duplicated logic)
- Error class hierarchy unified: `Verikloak::Audience::Error` now inherits from `Verikloak::Error`
- **BREAKING**: Minimum `verikloak` dependency raised to `>= 0.4.1, < 1.0.0`
- Dev dependency `rspec` pinned to `~> 3.13`, `rubocop-rspec` pinned to `~> 3.9`

### Fixed
- **`normalize_claims` observability**: `rescue StandardError` now captures the exception and emits a `warn` when `$DEBUG` is enabled, improving debuggability of malformed claims
- **`Audience.reset!` added**: New `reset!` class method for test teardown to prevent configuration leakage between examples