### PR TITLE
v1.0.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.0] - 2026-02-15
+
+### Fixed
+- **`resource_or_aud?` null/empty role handling**: `roles: [nil]` or `roles: [""]` no longer pass validation — roles are now compacted and empty-string-filtered before the presence check
+- **ERRORS.md**: Added missing `:any_match` profile to the supported profiles list
+- **`env_claims_key` nil validation**: Setting `env_claims_key` to `nil` or empty string now raises `ConfigurationError` immediately instead of silently causing all audience checks to fail with a confusing 403
+
+### Changed
+- **BREAKING**: Minimum `verikloak` dependency raised to `~> 1.0`
+- **v1.0.0 stable release**: Public API is now considered stable under Semantic Versioning
+
+---
+
 ## [0.4.0] - 2026-02-15
 
 ### Added

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -24,7 +24,7 @@ Content-Type: application/json
 
 ### Trigger details
 - Claims are read from `env[config.env_claims_key]` (default: `"verikloak.user"`). Missing claims are treated as `{}`.
-- Validation is delegated to `Verikloak::Audience::Checker.ok?`, which supports profiles `:strict_single`, `:allow_account`, and `:resource_or_aud`.
+- Validation is delegated to `Verikloak::Audience::Checker.ok?`, which supports profiles `:strict_single`, `:allow_account`, `:any_match`, and `:resource_or_aud`.
 - When validation fails and `config.suggest_in_logs` is true (default), the middleware emits a `warn` message to STDERR such as:
   ```
   [verikloak-audience] insufficient_audience; suggestion profile=:allow_account aud=["my-api","account"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    verikloak-audience (0.4.0)
+    verikloak-audience (1.0.0)
       rack (>= 2.2, < 4.0)
-      verikloak (>= 0.4.1, < 1.0.0)
+      verikloak (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -19,8 +19,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     json (2.18.1)
@@ -29,8 +29,8 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    net-http (0.6.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     parallel (1.27.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -89,12 +89,13 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    uri (1.0.4)
-    verikloak (0.4.1)
+    uri (1.1.1)
+    verikloak (1.0.0)
       faraday (>= 2.14.1, < 3.0)
       faraday-retry (>= 2.4.0, < 3.0)
-      json (~> 2.18)
+      json (~> 2.6)
       jwt (>= 2.7, < 4.0)
+      rack (>= 2.2, < 4.0)
 
 PLATFORMS
   aarch64-linux-musl

--- a/lib/verikloak/audience/checker.rb
+++ b/lib/verikloak/audience/checker.rb
@@ -90,8 +90,8 @@ module Verikloak
       # @param required [Array<String>]
       # @return [Boolean]
       def resource_or_aud?(claims, client, required)
-        roles = Array(claims.dig('resource_access', client, 'roles'))
-        return true unless roles.empty? # if roles for client exist, pass
+        roles = Array(claims.dig('resource_access', client, 'roles')).compact.reject { |r| r.to_s.empty? }
+        return true unless roles.empty? # if meaningful roles for client exist, pass
 
         # otherwise enforce allow_account semantics by default
         allow_account?(claims, required)

--- a/lib/verikloak/audience/configuration.rb
+++ b/lib/verikloak/audience/configuration.rb
@@ -71,12 +71,13 @@ module Verikloak
       # @return [void]
       def env_claims_key=(value)
         str = value&.to_s
-        if str.nil? || str.strip.empty?
+        stripped = str&.strip
+        if stripped.nil? || stripped.empty?
           raise Verikloak::Audience::ConfigurationError,
                 'env_claims_key must not be nil or empty'
         end
 
-        @env_claims_key = str
+        @env_claims_key = stripped
       end
 
       # Validate the configuration to ensure required values are present.

--- a/lib/verikloak/audience/configuration.rb
+++ b/lib/verikloak/audience/configuration.rb
@@ -67,9 +67,16 @@ module Verikloak
       end
 
       # @param value [#to_s, nil]
+      # @raise [ConfigurationError] when value is nil or blank
       # @return [void]
       def env_claims_key=(value)
-        @env_claims_key = value&.to_s
+        str = value&.to_s
+        if str.nil? || str.strip.empty?
+          raise Verikloak::Audience::ConfigurationError,
+                'env_claims_key must not be nil or empty'
+        end
+
+        @env_claims_key = str
       end
 
       # Validate the configuration to ensure required values are present.

--- a/lib/verikloak/audience/version.rb
+++ b/lib/verikloak/audience/version.rb
@@ -4,6 +4,6 @@ module Verikloak
   module Audience
     # Current gem version.
     # @return [String]
-    VERSION = '0.4.0'
+    VERSION = '1.0.0'
   end
 end

--- a/spec/audience_checker_spec.rb
+++ b/spec/audience_checker_spec.rb
@@ -61,6 +61,36 @@ RSpec.describe Verikloak::Audience::Checker do
     expect(described_class.ok?(claims, cfg)).to be true
   end
 
+  it "resource_or_aud falls back to allow_account when roles contain only nil" do
+    cfg.profile = :resource_or_aud
+    cfg.required_aud = ["rails-api"]
+    claims = {
+      "resource_access" => { "rails-api" => { "roles" => [nil] } },
+      "aud" => ["rails-api", "account"]
+    }
+    expect(described_class.ok?(claims, cfg)).to be true
+  end
+
+  it "resource_or_aud falls back to allow_account when roles contain only empty strings" do
+    cfg.profile = :resource_or_aud
+    cfg.required_aud = ["rails-api"]
+    claims = {
+      "resource_access" => { "rails-api" => { "roles" => [""] } },
+      "aud" => ["rails-api", "account"]
+    }
+    expect(described_class.ok?(claims, cfg)).to be true
+  end
+
+  it "resource_or_aud rejects when roles are nil/empty and aud doesn't match" do
+    cfg.profile = :resource_or_aud
+    cfg.required_aud = ["rails-api"]
+    claims = {
+      "resource_access" => { "rails-api" => { "roles" => [nil, ""] } },
+      "aud" => ["other-client"]
+    }
+    expect(described_class.ok?(claims, cfg)).to be false
+  end
+
   it "strict_single matches multiple audiences order-insensitively" do
     cfg.profile = :strict_single
     cfg.required_aud = ["a", "b"]

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -45,6 +45,34 @@ RSpec.describe Verikloak::Audience::Configuration do
     expect(cfg.env_claims_key).to eq("claims")
   end
 
+  it "strips whitespace from env_claims_key" do
+    cfg = described_class.new
+    cfg.env_claims_key = "  verikloak.user  "
+
+    expect(cfg.env_claims_key).to eq("verikloak.user")
+  end
+
+  it "raises ConfigurationError when env_claims_key is set to nil" do
+    cfg = described_class.new
+    expect { cfg.env_claims_key = nil }.to raise_error(
+      Verikloak::Audience::ConfigurationError, /must not be nil or empty/
+    )
+  end
+
+  it "raises ConfigurationError when env_claims_key is set to empty string" do
+    cfg = described_class.new
+    expect { cfg.env_claims_key = "" }.to raise_error(
+      Verikloak::Audience::ConfigurationError, /must not be nil or empty/
+    )
+  end
+
+  it "raises ConfigurationError when env_claims_key is whitespace only" do
+    cfg = described_class.new
+    expect { cfg.env_claims_key = "   " }.to raise_error(
+      Verikloak::Audience::ConfigurationError, /must not be nil or empty/
+    )
+  end
+
   describe "#validate!" do
     it "raises when required_aud is empty" do
       cfg = described_class.new

--- a/verikloak-audience.gemspec
+++ b/verikloak-audience.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.add_dependency 'verikloak', '>= 0.4.1', '< 1.0.0'
+  spec.add_dependency 'verikloak', '~> 1.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
### Fixed
- **`resource_or_aud?` null/empty role handling**: `roles: [nil]` or `roles: [""]` no longer pass validation — roles are now compacted and empty-string-filtered before the presence check
- **ERRORS.md**: Added missing `:any_match` profile to the supported profiles list
- **`env_claims_key` nil validation**: Setting `env_claims_key` to `nil` or empty string now raises `ConfigurationError` immediately instead of silently causing all audience checks to fail with a confusing 403

### Changed
- **BREAKING**: Minimum `verikloak` dependency raised to `~> 1.0`
- **v1.0.0 stable release**: Public API is now considered stable under Semantic Versioning