### PR TITLE
Restructure CI multi-Ruby testing to match verikloak core's layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,31 +14,12 @@ on:
 
 jobs:
   rspec:
-    name: RSpec (Ruby ${{ matrix.ruby }})
+    name: RSpec
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
       checks: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # Cover every Ruby series supported by the gemspec (>= 3.1).
-        # Tags are pinned to patch + Alpine versions so CI stays
-        # deterministic; bump them intentionally.
-        include:
-          - ruby: "3.1"
-            ruby_image: ruby:3.1.7-alpine3.21
-          - ruby: "3.2"
-            ruby_image: ruby:3.2.11-alpine3.23
-          - ruby: "3.3"
-            ruby_image: ruby:3.3.11-alpine3.23
-          - ruby: "3.4"
-            ruby_image: ruby:3.4.8-alpine3.23
-
-    env:
-      RUBY_IMAGE: ${{ matrix.ruby_image }}
 
     steps:
       - name: Checkout source
@@ -64,7 +45,7 @@ jobs:
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
         if: always()
         with:
-          name: RSpec Reports (Ruby ${{ matrix.ruby }})
+          name: RSpec Reports
           path: tmp/rspec/results.xml
           reporter: java-junit
         continue-on-error: true
@@ -82,28 +63,40 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: rspec-coverage-ruby-${{ matrix.ruby }}
+          name: rspec-coverage
           path: artifacts/
 
-  # The main-branch ruleset requires a single status named "RSpec".
-  # This job aggregates the matrix legs so the required check keeps a
-  # stable name no matter how the matrix evolves.
-  rspec-summary:
-    name: RSpec
+  compatibility:
+    # Verifies the gemspec's `required_ruby_version >= 3.1` claim on every
+    # supported minor Ruby, mirroring verikloak core's CI layout: the
+    # docker-based `rspec` job covers the pinned development Ruby (3.4);
+    # this matrix covers the rest without docker. Unlike core, no
+    # compat.gemfile is needed because this Gemfile does not pin an
+    # interpreter, so the locked dependency set installs as-is.
+    name: RSpec (Ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: rspec
-    # Run even when a leg fails so the required check reports failure
-    # instead of being skipped (skipped checks would satisfy the ruleset).
-    if: always()
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.1', '3.2', '3.3']
 
     steps:
-      - name: Fail unless every RSpec matrix leg succeeded
-        env:
-          RSPEC_RESULT: ${{ needs.rspec.result }}
-        run: |
-          echo "RSpec matrix result: ${RSPEC_RESULT}"
-          [ "${RSPEC_RESULT}" = "success" ]
+      - name: Checkout source
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run RSpec
+        run: bundle exec rspec --format progress
 
   rubocop:
     name: RuboCop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`Configuration#normalized_profile` / `#validated_profile`**: Shared profile coercion and validation helpers (Symbol coercion, default fallback, unknown-profile check) used by both `validate!` and `Checker`
 - **JSON 500 for request-time configuration errors**: When a `ConfigurationError` surfaces during a request (normally prevented by boot-time validation), the middleware now renders a JSON error response (`audience_configuration_error`, status 500) instead of leaking the exception through the Rack stack; the response body stays generic and the failure detail is written to the request logger
 - **`Checker.observed_audiences`**: Public helper returning the normalized audience values seen in a claims payload, used by the middleware so rejection logs show the same audiences the checker evaluated (including duck-typed `#to_hash` claims)
-- **CI Ruby matrix**: RSpec now runs against Ruby 3.1 / 3.2 / 3.3 / 3.4 (all series supported by the gemspec)
+- **CI Ruby matrix**: RSpec now runs against Ruby 3.1 / 3.2 / 3.3 / 3.4 (all series supported by the gemspec) — the Docker-based job covers the development Ruby (3.4) and a non-Docker `ruby/setup-ruby` matrix covers 3.1–3.3, mirroring verikloak core's CI layout
 - **Coverage floor**: SimpleCov now enforces a minimum line coverage of 90% in CI (not enforced for focused local runs)
 - **MAINTAINERS.md**: Release instructions referenced from the README now exist
 - Tests for the `Forbidden`/`Error`/`ConfigurationError` classes, the Railtie `discovery_url` guard, the `REQUEST_PATH` fallback, and Symbol inputs to the public checker predicates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2026-07-03
 
 ### Added
-- **Boot-time profile validation**: `Configuration#validate!` now rejects unknown `profile` values, so typos (e.g. `:strict_signle`) fail fast at startup instead of raising on the first request
+- **Boot-time profile validation**: `Configuration#validate!` now rejects unknown `profile` values, so misspellings (e.g. `:strict_signle` instead of `:strict_single`) fail fast at startup instead of raising on the first request
 - **`Configuration#normalized_profile` / `#validated_profile`**: Shared profile coercion and validation helpers (Symbol coercion, default fallback, unknown-profile check) used by both `validate!` and `Checker`
 - **JSON 500 for request-time configuration errors**: When a `ConfigurationError` surfaces during a request (normally prevented by boot-time validation), the middleware now renders a JSON error response (`audience_configuration_error`, status 500) instead of leaking the exception through the Rack stack; the response body stays generic and the failure detail is written to the request logger
 - **`Checker.observed_audiences`**: Public helper returning the normalized audience values seen in a claims payload, used by the middleware so rejection logs show the same audiences the checker evaluated (including duck-typed `#to_hash` claims)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-24
   arm64-darwin-25
+  x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/compose.yml
+++ b/compose.yml
@@ -4,9 +4,6 @@ services:
     build:
       context: .
       dockerfile: docker/dev.Dockerfile
-      args:
-        # Overridable base image so CI can run the suite across Ruby versions
-        RUBY_IMAGE: ${RUBY_IMAGE:-ruby:3.4.8-alpine3.23}
     environment:
       # Passed through from the host so CI can enable coverage reporting
       # and its minimum-coverage floor

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,7 +1,5 @@
 # docker/dev.Dockerfile
-# Overridable so CI can exercise every supported Ruby (>= 3.1) via a matrix
-ARG RUBY_IMAGE=ruby:3.4.8-alpine3.23
-FROM ${RUBY_IMAGE}
+FROM ruby:3.4.8-alpine3.23
 
 # Base packages:
 # - Runtime: bash (for CI commands), git (bundler-audit update), openssl (runtime lib), tzdata, libstdc++
@@ -31,13 +29,7 @@ COPY Gemfile Gemfile.lock ./
 # Faster, more reliable bundler installs
 ARG BUNDLE_FROZEN=1
 ENV BUNDLE_JOBS=4 BUNDLE_RETRY=3 BUNDLE_FROZEN=$BUNDLE_FROZEN
-# Install the exact Bundler version recorded in Gemfile.lock (the line after
-# the BUNDLED WITH marker) so older base images resolve the lockfile
-# deterministically. Anchored on the marker rather than file position so
-# trailing lines can't break the parse. Note: whoever re-locks the file pins
-# the Bundler used here, and Bundler 2.7+ drops Ruby 3.1 support.
-RUN gem install bundler:"$(awk '/^BUNDLED WITH/ { getline; gsub(/[[:space:]]/, ""); print; exit }' Gemfile.lock)" --no-document && \
-    bundle install
+RUN bundle install
 
 # App source
 COPY . .


### PR DESCRIPTION
## Summary

Follow-up to #32: this commit was pushed to the branch at the same time #32 was merged (head `d9f5710`), so it missed the merge. It restructures the CI multi-Ruby testing to match verikloak core's layout.

### Changes
- **`RSpec` returns to a single Docker-based job** (development Ruby 3.4, coverage + 90% floor, JUnit report). The job name again satisfies the main-branch ruleset's required check natively, so the `rspec-summary` aggregate job added in #32 is removed.
- **Ruby 3.1 / 3.2 / 3.3 move to a non-Docker `compatibility` matrix** using `ruby/setup-ruby` (same SHA pin as verikloak core) with `bundler-cache: true`.
- **No compat.gemfile needed** (intentional difference from core, documented in a job comment): this gem's Gemfile does not pin an interpreter, so the compatibility legs install the exact locked dependency set — stricter than a fresh resolve.
- **Gemfile.lock gains the `x86_64-linux` platform** (one line): the lockfile only had musl/darwin platforms, and `bundler-cache` performs frozen installs, so glibc runners need it.
- **Docker machinery reverted**: the `RUBY_IMAGE` build arg (Dockerfile + compose.yml) and the `BUNDLED WITH` Bundler pin existed only for the Docker matrix and are removed; the `SIMPLECOV`/`CI` env passthrough stays (coverage measurement).
- CHANGELOG 1.1.0 CI bullet updated to describe the new layout.

### Why
Family CI comparison showed verikloak core uses a hybrid layout (Docker for the dev Ruby + a lightweight `setup-ruby` matrix for older Rubies). Aligning keeps the pipelines consistent across the gem family and avoids four uncached Docker image builds per run.

## Test plan
- CI on commit `b24191f` (branch push) already passed all six jobs, including the first run of the new compatibility matrix: RSpec (Docker), RSpec (Ruby 3.1/3.2/3.3), RuboCop, Bundler Audit.
- Local: 109 examples, 0 failures; RuboCop no offenses; ci.yml YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
